### PR TITLE
Center audio block and add volume popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,7 @@
       </div>
       <canvas id="waveform" width="280" height="60"></canvas>
       <div class="progress-bar-audio"><div class="progress"></div></div>
+      <div id="volumePopup" class="volume-popup"></div>
       <div class="control-buttons">
         <button id="prevTrack">⏮</button>
         <button id="playPause">▶</button>

--- a/script.js
+++ b/script.js
@@ -1045,16 +1045,23 @@ if (audio) {
     audio.currentTime = pct * audio.duration;
   });
 
-  master.addEventListener('input', () => {
+  const volumePopup = document.getElementById('volumePopup');
+  let hidePopupId = null;
+  function showVolume() {
+    if (!volumePopup) return;
+    volumePopup.textContent = Math.round(master.value * 100) + '%';
+    volumePopup.classList.add('show');
+    clearTimeout(hidePopupId);
+    hidePopupId = setTimeout(() => volumePopup.classList.remove('show'), 800);
+  }
+  function updateVolume() {
     gainL.gain.value = master.value * left.value;
     gainR.gain.value = master.value * right.value;
-  });
-  left.addEventListener('input', () => {
-    gainL.gain.value = master.value * left.value;
-  });
-  right.addEventListener('input', () => {
-    gainR.gain.value = master.value * right.value;
-  });
+    showVolume();
+  }
+  master.addEventListener('input', updateVolume);
+  left.addEventListener('input', updateVolume);
+  right.addEventListener('input', updateVolume);
 
   const soundSection = document.getElementById('sound');
   let soundVisible = false;

--- a/style.css
+++ b/style.css
@@ -747,11 +747,12 @@ body.light #introCanvas { background: #eee; border-color: #87ceeb; }
 
 /* Custom audio player */
 .audio-player {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 10px;
-  margin-top: 20px;
+  margin: 20px auto;
   background: rgba(0, 0, 0, 0.2);
   padding: 15px;
   border-radius: 12px;
@@ -858,6 +859,25 @@ body.light .audio-player input[type=range]::-webkit-slider-thumb {
 .album-title {
   margin-top: 15px;
   font-weight: bold;
+}
+
+.volume-popup {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, -10px);
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.volume-popup.show {
+  opacity: 1;
 }
 .calc-history {
   margin-top: 10px;


### PR DESCRIPTION
## Summary
- center the audio player and give it relative positioning
- show a popup when adjusting volume

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685ae40905ec832789e81310222fc656