### PR TITLE
Implement popup volume controls with keyboard support

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,11 +134,17 @@
     <div class="audio-player">
       <div class="player-upper">
         <img id="albumArt" class="album-art" src="https://via.placeholder.com/80" alt="album" />
-        <div class="volume-controls">
-          <input type="range" id="masterVolume" min="0" max="1" step="0.01" value="1">
-          <div class="lr-volume">
-            L <input type="range" id="leftVolume" min="0" max="1" step="0.01" value="1">
-            R <input type="range" id="rightVolume" min="0" max="1" step="0.01" value="1">
+        <button id="volumeBtn" class="vol-btn">🔊</button>
+        <div id="volumeBox" class="volume-box">
+          <div class="volume-controls">
+            <input type="range" id="masterVolume" min="0" max="1" step="0.01" value="1">
+            <span id="masterLabel" class="vol-label">100%</span>
+            <div class="lr-volume">
+              L <input type="range" id="leftVolume" min="0" max="1" step="0.01" value="1">
+              <span id="leftLabel" class="vol-label">100%</span>
+              R <input type="range" id="rightVolume" min="0" max="1" step="0.01" value="1">
+              <span id="rightLabel" class="vol-label">100%</span>
+            </div>
           </div>
         </div>
       </div>

--- a/script.js
+++ b/script.js
@@ -977,6 +977,11 @@ if (audio) {
   const master = document.getElementById('masterVolume');
   const left = document.getElementById('leftVolume');
   const right = document.getElementById('rightVolume');
+  const volumeBtn = document.getElementById('volumeBtn');
+  const volumeBox = document.getElementById('volumeBox');
+  const masterLabel = document.getElementById('masterLabel');
+  const leftLabel = document.getElementById('leftLabel');
+  const rightLabel = document.getElementById('rightLabel');
   const playBtn = document.getElementById('playPause');
   const prevBtn = document.getElementById('prevTrack');
   const nextBtn = document.getElementById('nextTrack');
@@ -1049,16 +1054,30 @@ if (audio) {
   let hidePopupId = null;
   function showVolume() {
     if (!volumePopup) return;
-    volumePopup.textContent = Math.round(master.value * 100) + '%';
+    volumePopup.textContent = `M ${Math.round(master.value * 100)}% | L ${Math.round(left.value * 100)}% | R ${Math.round(right.value * 100)}%`;
     volumePopup.classList.add('show');
     clearTimeout(hidePopupId);
     hidePopupId = setTimeout(() => volumePopup.classList.remove('show'), 800);
   }
+  function showVolumeBox() {
+    if (!volumeBox) return;
+    volumeBox.classList.add('show');
+    clearTimeout(hidePopupId);
+    hidePopupId = setTimeout(() => volumeBox.classList.remove('show'), 2000);
+  }
+  function updateLabels() {
+    if (masterLabel) masterLabel.textContent = Math.round(master.value * 100) + '%';
+    if (leftLabel) leftLabel.textContent = Math.round(left.value * 100) + '%';
+    if (rightLabel) rightLabel.textContent = Math.round(right.value * 100) + '%';
+  }
   function updateVolume() {
     gainL.gain.value = master.value * left.value;
     gainR.gain.value = master.value * right.value;
+    updateLabels();
     showVolume();
+    showVolumeBox();
   }
+  if (volumeBtn) volumeBtn.addEventListener('click', showVolumeBox);
   master.addEventListener('input', updateVolume);
   left.addEventListener('input', updateVolume);
   right.addEventListener('input', updateVolume);
@@ -1071,10 +1090,19 @@ if (audio) {
   }
   document.addEventListener('keydown', e => {
     if (!soundVisible) return;
-    if (e.code === 'ArrowRight') { load(trackIndex + 1); }
-    if (e.code === 'ArrowLeft') { load(trackIndex - 1); }
+    if (volumeBox && volumeBox.classList.contains('show')) {
+      if (e.code === 'ArrowUp') { master.value = Math.min(1, parseFloat(master.value) + 0.05); updateVolume(); e.preventDefault(); }
+      else if (e.code === 'ArrowDown') { master.value = Math.max(0, parseFloat(master.value) - 0.05); updateVolume(); e.preventDefault(); }
+      else if (e.code === 'ArrowLeft') { left.value = Math.max(0, parseFloat(left.value) - 0.05); updateVolume(); e.preventDefault(); }
+      else if (e.code === 'ArrowRight') { right.value = Math.min(1, parseFloat(right.value) + 0.05); updateVolume(); e.preventDefault(); }
+    } else {
+      if (e.code === 'ArrowRight') { load(trackIndex + 1); }
+      else if (e.code === 'ArrowLeft') { load(trackIndex - 1); }
+      else if (e.code === 'ArrowUp' || e.code === 'ArrowDown') { showVolumeBox(); }
+    }
   });
   load(0);
+  updateLabels();
 }
 
 

--- a/style.css
+++ b/style.css
@@ -879,6 +879,39 @@ body.light .audio-player input[type=range]::-webkit-slider-thumb {
 .volume-popup.show {
   opacity: 1;
 }
+
+.volume-box {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, -10px);
+  background: rgba(0, 0, 0, 0.8);
+  padding: 8px;
+  border-radius: 6px;
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+}
+.volume-box.show {
+  display: flex;
+}
+.vol-btn {
+  background: #4caf50;
+  color: #fff;
+  border: none;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-left: 6px;
+}
+.vol-btn:hover {
+  background: #3a8b3a;
+}
+.vol-label {
+  font-size: 0.8rem;
+  margin-left: 4px;
+}
 .calc-history {
   margin-top: 10px;
   max-height: 100px;


### PR DESCRIPTION
## Summary
- display separate volume percentages for each channel
- show volume sliders only when triggered
- allow adjusting volumes with arrow keys

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685ae64d40508327bb460e43066b0e55