### PR TITLE
Modify audio sliders layout and style

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,12 +146,12 @@
       <div id="volLeft" class="vol-popup left">
         <input id="volumeLeft" type="range" min="0" max="1" step="0.01" value="1" orient="vertical">
         <label for="volumeLeft">L</label>
-        <input id="volumeMaster" type="range" min="0" max="1" step="0.01" value="1" orient="vertical">
-        <label for="volumeMaster">M</label>
-      </div>
-      <div id="volRight" class="vol-popup right">
         <input id="volumeRight" type="range" min="0" max="1" step="0.01" value="1" orient="vertical">
         <label for="volumeRight">R</label>
+      </div>
+      <div id="volRight" class="vol-popup right">
+        <input id="volumeMaster" type="range" min="0" max="1" step="0.01" value="1" orient="vertical">
+        <label for="volumeMaster">M</label>
       </div>
       <audio id="audio"></audio>
     </div>

--- a/style.css
+++ b/style.css
@@ -891,4 +891,5 @@ body.light .progress-bar-audio { background: #b5d7b5; }
   height: 80px;
   writing-mode: bt-lr;
   -webkit-appearance: slider-vertical;
+  accent-color: #4caf50;
 }


### PR DESCRIPTION
## Summary
- move left and right volume sliders to left popup
- move master volume slider to right popup
- make volume slider controls green

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aef8f4434832799daef62a2cb1615